### PR TITLE
feat: dashboard v1 with VPS and AI routing views

### DIFF
--- a/src/app/dashboard/data.ts
+++ b/src/app/dashboard/data.ts
@@ -1,0 +1,295 @@
+import type { LucideIcon } from "lucide-react";
+import { MessageSquare, Server, Waypoints } from "lucide-react";
+
+/* -------------------------------------------------------------------------- */
+/*  Tools                                                                     */
+/* -------------------------------------------------------------------------- */
+
+export type ToolId = "vps" | "ai" | "chat";
+
+export type Tool = {
+  id: ToolId;
+  name: string;
+  tag: string;
+  icon: LucideIcon;
+  createLabel: string;
+  searchLabel: string;
+};
+
+export const TOOLS: readonly Tool[] = [
+  {
+    id: "vps",
+    name: "VPS Control",
+    tag: "Infrastructure",
+    icon: Server,
+    createLabel: "New instance",
+    searchLabel: "Search instances",
+  },
+  {
+    id: "ai",
+    name: "AI Router",
+    tag: "Models",
+    icon: Waypoints,
+    createLabel: "New route",
+    searchLabel: "Search routes",
+  },
+  {
+    id: "chat",
+    name: "Chat AI",
+    tag: "Assistants",
+    icon: MessageSquare,
+    createLabel: "New conversation",
+    searchLabel: "Search conversations",
+  },
+] as const;
+
+/* -------------------------------------------------------------------------- */
+/*  VPS instances                                                             */
+/* -------------------------------------------------------------------------- */
+
+export type VpsStatus = "running" | "stopped" | "rebooting";
+
+export type VpsInstance = {
+  id: string;
+  name: string;
+  region: string;
+  ipv4: string;
+  status: VpsStatus;
+  cpu: number;
+  memory: number;
+  disk: number;
+  uptime: string;
+  vcpu: number;
+  memoryGb: number;
+  diskGb: number;
+};
+
+export const VPS_INSTANCES: VpsInstance[] = [
+  {
+    id: "v1",
+    name: "edge-sg-1",
+    region: "Singapore · SG1",
+    ipv4: "139.162.42.18",
+    status: "running",
+    cpu: 18,
+    memory: 42,
+    disk: 28,
+    uptime: "14d 3h",
+    vcpu: 2,
+    memoryGb: 4,
+    diskGb: 80,
+  },
+  {
+    id: "v2",
+    name: "worker-de-2",
+    region: "Frankfurt · FRA1",
+    ipv4: "139.162.55.102",
+    status: "running",
+    cpu: 67,
+    memory: 71,
+    disk: 54,
+    uptime: "3d 11h",
+    vcpu: 4,
+    memoryGb: 8,
+    diskGb: 160,
+  },
+  {
+    id: "v3",
+    name: "dev-sandbox",
+    region: "Jakarta · ID1",
+    ipv4: "—",
+    status: "stopped",
+    cpu: 0,
+    memory: 0,
+    disk: 12,
+    uptime: "—",
+    vcpu: 1,
+    memoryGb: 2,
+    diskGb: 40,
+  },
+  {
+    id: "v4",
+    name: "bot-runner",
+    region: "US West · SJC1",
+    ipv4: "139.162.98.4",
+    status: "running",
+    cpu: 23,
+    memory: 55,
+    disk: 18,
+    uptime: "9d 2h",
+    vcpu: 2,
+    memoryGb: 4,
+    diskGb: 80,
+  },
+];
+
+/* -------------------------------------------------------------------------- */
+/*  AI Router routes                                                          */
+/* -------------------------------------------------------------------------- */
+
+export type AiRoute = {
+  id: string;
+  name: string;
+  path: string;
+  model: string;
+  fallback: string;
+  provider: "anthropic" | "openai" | "voyage";
+  p50: string;
+  p95: string;
+  errors: string;
+  requests24h: number;
+  active: boolean;
+};
+
+export const AI_ROUTES: AiRoute[] = [
+  {
+    id: "r1",
+    name: "default",
+    path: "/v1/chat/completions",
+    model: "claude-opus-4",
+    fallback: "gpt-5",
+    provider: "anthropic",
+    p50: "124ms",
+    p95: "612ms",
+    errors: "0.02%",
+    requests24h: 12453,
+    active: true,
+  },
+  {
+    id: "r2",
+    name: "fast",
+    path: "/v1/chat/completions",
+    model: "gpt-4o-mini",
+    fallback: "claude-haiku",
+    provider: "openai",
+    p50: "89ms",
+    p95: "412ms",
+    errors: "0.01%",
+    requests24h: 4211,
+    active: true,
+  },
+  {
+    id: "r3",
+    name: "embed",
+    path: "/v1/embed",
+    model: "voyage-3",
+    fallback: "—",
+    provider: "voyage",
+    p50: "32ms",
+    p95: "89ms",
+    errors: "0.00%",
+    requests24h: 1890,
+    active: true,
+  },
+];
+
+export type AiCall = {
+  ts: string;
+  method: "POST";
+  path: string;
+  model: string;
+  ms: string;
+  status: 200 | 429 | 500;
+};
+
+export const AI_RECENT_CALLS: AiCall[] = [
+  { ts: "19:02:14", method: "POST", path: "/v1/chat/completions", model: "claude-opus-4", ms: "312ms", status: 200 },
+  { ts: "19:02:12", method: "POST", path: "/v1/chat/completions", model: "gpt-5", ms: "214ms", status: 200 },
+  { ts: "19:02:09", method: "POST", path: "/v1/embed", model: "voyage-3", ms: "89ms", status: 200 },
+  { ts: "19:02:05", method: "POST", path: "/v1/chat/completions", model: "claude-opus-4", ms: "441ms", status: 200 },
+  { ts: "19:01:58", method: "POST", path: "/v1/chat/completions", model: "gpt-5", ms: "—", status: 429 },
+  { ts: "19:01:51", method: "POST", path: "/v1/chat/completions", model: "claude-opus-4", ms: "287ms", status: 200 },
+];
+
+/* -------------------------------------------------------------------------- */
+/*  Chat conversations                                                        */
+/* -------------------------------------------------------------------------- */
+
+export type ChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+};
+
+export type ChatConversation = {
+  id: string;
+  title: string;
+  snippet: string;
+  model: string;
+  updatedAt: string;
+  messages: ChatMessage[];
+};
+
+export const CHAT_CONVERSATIONS: ChatConversation[] = [
+  {
+    id: "c1",
+    title: "Debounce a react effect",
+    snippet: "Show me the minimal version.",
+    model: "claude-opus-4",
+    updatedAt: "just now",
+    messages: [
+      { id: "m1", role: "user", content: "How do I debounce a react effect?" },
+      {
+        id: "m2",
+        role: "assistant",
+        content:
+          "Usually you don't debounce the effect itself — you debounce the value that feeds it. Derive a debounced version of your input and only let the effect run when the debounced value changes.",
+      },
+      { id: "m3", role: "user", content: "Show me the minimal version." },
+      {
+        id: "m4",
+        role: "assistant",
+        content:
+          "```tsx\nconst debounced = useDebouncedValue(query, 300);\n\nuseEffect(() => {\n  if (!debounced) return;\n  fetch(`/api/search?q=${debounced}`).then(/* … */);\n}, [debounced]);\n```",
+      },
+    ],
+  },
+  {
+    id: "c2",
+    title: "Next.js 16 server actions",
+    snippet: "Explain useActionState.",
+    model: "claude-opus-4",
+    updatedAt: "2h ago",
+    messages: [
+      { id: "m1", role: "user", content: "Explain useActionState in Next.js 16." },
+      {
+        id: "m2",
+        role: "assistant",
+        content:
+          "`useActionState(action, initialState)` returns `[state, formAction, isPending]`. The action has the shape `(prev, formData) => newState`, so you can drive a whole form flow from a single server action while keeping the UI inline.",
+      },
+    ],
+  },
+  {
+    id: "c3",
+    title: "Supabase OAuth flow",
+    snippet: "Walk me through PKCE.",
+    model: "gpt-5",
+    updatedAt: "yesterday",
+    messages: [
+      { id: "m1", role: "user", content: "Walk me through the PKCE flow in Supabase OAuth." },
+      {
+        id: "m2",
+        role: "assistant",
+        content:
+          "Browser generates a code verifier + challenge, sends the challenge to the provider, receives a code back at your callback, then exchanges code + verifier for a session. Supabase's `exchangeCodeForSession` handles the last step.",
+      },
+    ],
+  },
+  {
+    id: "c4",
+    title: "VPS setup on bare linux",
+    snippet: "Best way to install systemd units?",
+    model: "claude-opus-4",
+    updatedAt: "2d ago",
+    messages: [
+      { id: "m1", role: "user", content: "Best way to install systemd units for a node app?" },
+      {
+        id: "m2",
+        role: "assistant",
+        content:
+          "Drop a `.service` file in `/etc/systemd/system/`, run `systemctl daemon-reload`, then `systemctl enable --now your-app`. Use `Restart=always` and `WorkingDirectory` so the app survives reboots.",
+      },
+    ],
+  },
+];

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { DashboardShell } from "./shell";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  description:
+    "Authenticated workspace that hosts every tool in one place — VPS Control, AI Router, and Chat AI.",
+};
+
+export default function DashboardPage() {
+  return <DashboardShell />;
+}

--- a/src/app/dashboard/shell.tsx
+++ b/src/app/dashboard/shell.tsx
@@ -1,0 +1,664 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import {
+  ChevronDown,
+  ExternalLink,
+  HelpCircle,
+  Home,
+  Menu,
+  Plus,
+  Search,
+  Settings,
+  X,
+} from "lucide-react";
+
+import {
+  AI_ROUTES,
+  CHAT_CONVERSATIONS,
+  TOOLS,
+  VPS_INSTANCES,
+} from "./data";
+import type { Tool, ToolId } from "./data";
+import {
+  AiRouterView,
+  ChatView,
+  PlaceholderView,
+  VpsView,
+} from "./views";
+
+/* -------------------------------------------------------------------------- */
+/*  Sub-sidebar sections                                                      */
+/* -------------------------------------------------------------------------- */
+
+type SubItem = { id: string; label: string; external?: boolean };
+type SubSection = { title: string; items: SubItem[] };
+
+const TOOL_SECTIONS: Record<ToolId, SubSection[]> = {
+  vps: [
+    {
+      title: "Instances",
+      items: VPS_INSTANCES.map((i) => ({ id: i.id, label: i.name })),
+    },
+    {
+      title: "Configuration",
+      items: [
+        { id: "vps:ssh-keys", label: "SSH Keys" },
+        { id: "vps:snapshots", label: "Snapshots" },
+        { id: "vps:firewalls", label: "Firewalls" },
+      ],
+    },
+    {
+      title: "Platform",
+      items: [
+        { id: "vps:billing", label: "Billing" },
+        { id: "vps:activity", label: "Activity Log" },
+        { id: "vps:webhooks", label: "Webhooks", external: true },
+      ],
+    },
+  ],
+  ai: [
+    {
+      title: "Routes",
+      items: AI_ROUTES.map((r) => ({ id: r.id, label: r.name })),
+    },
+    {
+      title: "Configuration",
+      items: [
+        { id: "ai:keys", label: "API Keys" },
+        { id: "ai:models", label: "Models" },
+        { id: "ai:fallbacks", label: "Fallbacks" },
+      ],
+    },
+    {
+      title: "Platform",
+      items: [
+        { id: "ai:usage", label: "Usage" },
+        { id: "ai:billing", label: "Billing" },
+        { id: "ai:webhooks", label: "Webhooks", external: true },
+      ],
+    },
+  ],
+  chat: [
+    {
+      title: "Conversations",
+      items: CHAT_CONVERSATIONS.map((c) => ({ id: c.id, label: c.title })),
+    },
+    {
+      title: "Configuration",
+      items: [
+        { id: "chat:models", label: "Models" },
+        { id: "chat:prompts", label: "System Prompts" },
+        { id: "chat:memory", label: "Memory" },
+      ],
+    },
+    {
+      title: "Platform",
+      items: [{ id: "chat:usage", label: "Usage" }],
+    },
+  ],
+};
+
+const PLACEHOLDER_LABELS: Record<string, { title: string; description: string }> = {
+  "vps:ssh-keys": { title: "SSH Keys", description: "Manage the keys that can sign into your instances." },
+  "vps:snapshots": { title: "Snapshots", description: "Point-in-time copies of your instance volumes." },
+  "vps:firewalls": { title: "Firewalls", description: "Per-instance ingress and egress rules." },
+  "vps:billing": { title: "Billing", description: "Hourly usage broken down per instance and region." },
+  "vps:activity": { title: "Activity Log", description: "Provisioning, reboots, and snapshot events." },
+  "vps:webhooks": { title: "Webhooks", description: "Push instance events into your own backend." },
+  "ai:keys": { title: "API Keys", description: "Issue and rotate keys that hit the router." },
+  "ai:models": { title: "Models", description: "Available models per provider and route." },
+  "ai:fallbacks": { title: "Fallbacks", description: "Per-route fallback chain when the primary model fails." },
+  "ai:usage": { title: "Usage", description: "Tokens, requests, and spend across the router." },
+  "ai:billing": { title: "Billing", description: "Invoices, credits, and payment method." },
+  "ai:webhooks": { title: "Webhooks", description: "Delivery hooks for completion and error events." },
+  "chat:models": { title: "Models", description: "Default and per-conversation model selection." },
+  "chat:prompts": { title: "System Prompts", description: "Reusable prompt blocks pinned across conversations." },
+  "chat:memory": { title: "Memory", description: "Long-term memory entries the assistant references." },
+  "chat:usage": { title: "Usage", description: "Tokens and conversation activity over time." },
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Shell                                                                     */
+/* -------------------------------------------------------------------------- */
+
+export function DashboardShell() {
+  const [activeTool, setActiveTool] = useState<ToolId>("vps");
+  const [activeItems, setActiveItems] = useState<Record<ToolId, string>>({
+    vps: VPS_INSTANCES[0].id,
+    ai: AI_ROUTES[0].id,
+    chat: CHAT_CONVERSATIONS[0].id,
+  });
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const tool = useMemo(
+    () => TOOLS.find((t) => t.id === activeTool) ?? TOOLS[0],
+    [activeTool],
+  );
+
+  const sections = TOOL_SECTIONS[activeTool];
+
+  const setItem = (id: string) =>
+    setActiveItems((prev) => ({ ...prev, [activeTool]: id }));
+
+  const openTool = (id: ToolId) => {
+    setActiveTool(id);
+    setDrawerOpen(false);
+  };
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden bg-[#1c1c1c] text-white selection:bg-[#3ecf8e]/30 selection:text-white">
+      <TopBar
+        tool={tool}
+        onMenuOpen={() => setDrawerOpen(true)}
+      />
+
+      <div className="flex min-h-0 flex-1">
+        {/* Primary sidebar (icon rail) — desktop only */}
+        <PrimarySidebar
+          activeTool={activeTool}
+          onChange={openTool}
+        />
+
+        {/* Sub-sidebar — desktop only */}
+        <SubSidebar
+          tool={tool}
+          sections={sections}
+          activeItem={activeItems[activeTool]}
+          onSelectItem={setItem}
+        />
+
+        {/* Main working surface */}
+        <main className="flex min-w-0 flex-1 flex-col overflow-y-auto bg-[#1c1c1c]">
+          {renderMain(activeTool, activeItems[activeTool])}
+        </main>
+      </div>
+
+      {/* Mobile drawer */}
+      {drawerOpen ? (
+        <MobileDrawer
+          tool={tool}
+          sections={sections}
+          activeTool={activeTool}
+          activeItem={activeItems[activeTool]}
+          onChangeTool={openTool}
+          onSelectItem={(id) => {
+            setItem(id);
+            setDrawerOpen(false);
+          }}
+          onClose={() => setDrawerOpen(false)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Main content router                                                       */
+/* -------------------------------------------------------------------------- */
+
+function renderMain(activeTool: ToolId, activeItemId: string): React.ReactNode {
+  // Configuration / Platform pages use prefixed IDs (e.g. "vps:ssh-keys")
+  if (activeItemId.includes(":")) {
+    const meta = PLACEHOLDER_LABELS[activeItemId];
+    return (
+      <PlaceholderView
+        title={meta?.title ?? "Coming soon"}
+        description={
+          meta?.description ?? "This page hasn't been built yet."
+        }
+      />
+    );
+  }
+
+  if (activeTool === "vps") {
+    const instance =
+      VPS_INSTANCES.find((i) => i.id === activeItemId) ?? VPS_INSTANCES[0];
+    return <VpsView instance={instance} />;
+  }
+  if (activeTool === "ai") {
+    const route = AI_ROUTES.find((r) => r.id === activeItemId) ?? AI_ROUTES[0];
+    return <AiRouterView route={route} />;
+  }
+  const conversation =
+    CHAT_CONVERSATIONS.find((c) => c.id === activeItemId) ??
+    CHAT_CONVERSATIONS[0];
+  return <ChatView conversation={conversation} />;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Top bar                                                                   */
+/* -------------------------------------------------------------------------- */
+
+function TopBar({
+  tool,
+  onMenuOpen,
+}: {
+  tool: Tool;
+  onMenuOpen: () => void;
+}) {
+  return (
+    <header className="flex h-12 shrink-0 items-center justify-between border-b border-white/[0.08] bg-[#0c0c0c] px-2 sm:px-3">
+      <div className="flex min-w-0 items-center gap-1">
+        <button
+          type="button"
+          aria-label="Open navigation"
+          onClick={onMenuOpen}
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-white/70 transition-colors hover:bg-white/5 hover:text-white sm:hidden"
+        >
+          <Menu className="h-4 w-4" aria-hidden />
+        </button>
+
+        <Link
+          href="/"
+          className="flex h-8 items-center gap-2 rounded-md px-2 text-[13px] font-medium tracking-[-0.01em] text-white/85 transition-colors hover:bg-white/5 hover:text-white"
+        >
+          <span
+            aria-hidden
+            className="inline-block h-2 w-2 rounded-full bg-[#3ecf8e] shadow-[0_0_8px_#3ecf8e]"
+          />
+          yoga<span className="text-[#3ecf8e]">.</span>
+        </Link>
+
+        <Crumb />
+
+        <button
+          type="button"
+          className="hidden h-8 items-center gap-1.5 rounded-md px-2 text-[13px] text-white/75 transition-colors hover:bg-white/5 hover:text-white sm:inline-flex"
+        >
+          portfolio
+          <span className="rounded-full border border-white/[0.08] bg-white/[0.04] px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-white/50">
+            free
+          </span>
+          <ChevronDown className="h-3 w-3 text-white/40" aria-hidden />
+        </button>
+
+        <span className="hidden sm:inline">
+          <Crumb />
+        </span>
+
+        <button
+          type="button"
+          className="inline-flex h-8 min-w-0 items-center gap-1.5 rounded-md px-2 text-[13px] text-white/85 transition-colors hover:bg-white/5"
+        >
+          <tool.icon className="h-3.5 w-3.5 text-white/60" aria-hidden />
+          <span className="truncate">{tool.name}</span>
+          <span className="rounded-full border border-[#3ecf8e]/20 bg-[#3ecf8e]/10 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em] text-[#3ecf8e]">
+            dev
+          </span>
+          <ChevronDown className="h-3 w-3 text-white/40" aria-hidden />
+        </button>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-1">
+        <button
+          type="button"
+          className="hidden h-8 items-center gap-2 rounded-md border border-white/[0.08] bg-white/[0.03] pr-1.5 pl-2.5 text-[12px] text-white/55 transition-colors hover:border-white/[0.12] hover:bg-white/[0.06] hover:text-white/80 md:inline-flex"
+        >
+          <Search className="h-3 w-3" aria-hidden />
+          <span>Search…</span>
+          <kbd className="rounded border border-white/[0.08] bg-white/[0.04] px-1 py-0.5 font-mono text-[10px] text-white/40">
+            ⌘K
+          </kbd>
+        </button>
+
+        <button
+          type="button"
+          aria-label="Search"
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-white/60 transition-colors hover:bg-white/5 hover:text-white md:hidden"
+        >
+          <Search className="h-4 w-4" aria-hidden />
+        </button>
+
+        <button
+          type="button"
+          aria-label="Help"
+          className="hidden h-8 w-8 items-center justify-center rounded-md text-white/60 transition-colors hover:bg-white/5 hover:text-white sm:inline-flex"
+        >
+          <HelpCircle className="h-4 w-4" aria-hidden />
+        </button>
+
+        <button
+          type="button"
+          aria-label="Account"
+          className="ml-1 inline-flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-[#3ecf8e] to-[#24b47e] font-mono text-[11px] font-medium text-[#171717] hover:opacity-90"
+        >
+          y
+        </button>
+      </div>
+    </header>
+  );
+}
+
+function Crumb() {
+  return (
+    <span aria-hidden className="px-1 text-white/25">
+      /
+    </span>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Primary sidebar (icon rail, no expand)                                    */
+/* -------------------------------------------------------------------------- */
+
+function PrimarySidebar({
+  activeTool,
+  onChange,
+}: {
+  activeTool: ToolId;
+  onChange: (id: ToolId) => void;
+}) {
+  return (
+    <div className="relative hidden w-12 shrink-0 sm:block">
+      <aside className="group absolute inset-y-0 left-0 z-20 flex w-12 flex-col overflow-hidden border-r border-white/[0.08] bg-[#0f0f0f] py-2 transition-[width] duration-200 ease-out hover:w-[220px] hover:shadow-[8px_0_24px_rgba(0,0,0,0.35)]">
+        <nav
+          aria-label="Tools"
+          className="flex flex-col gap-0.5 px-1.5"
+        >
+          <RailButton
+            icon={<Home className="h-4 w-4" aria-hidden />}
+            label="Home"
+            href="/"
+          />
+
+          <Separator />
+
+          {TOOLS.map((t) => (
+            <RailButton
+              key={t.id}
+              icon={<t.icon className="h-4 w-4" aria-hidden />}
+              label={t.name}
+              active={t.id === activeTool}
+              onClick={() => onChange(t.id)}
+            />
+          ))}
+        </nav>
+
+        <div className="mt-auto flex flex-col gap-0.5 px-1.5">
+          <Separator />
+          <RailButton
+            icon={<Settings className="h-4 w-4" aria-hidden />}
+            label="Settings"
+          />
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function Separator() {
+  return <span aria-hidden className="my-1 h-px w-full bg-white/[0.06]" />;
+}
+
+function RailButton({
+  icon,
+  label,
+  active,
+  onClick,
+  href,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  active?: boolean;
+  onClick?: () => void;
+  href?: string;
+}) {
+  const cls = `relative flex h-9 w-full items-center gap-2 rounded-md text-[13px] transition-colors ${
+    active
+      ? "bg-white/[0.06] text-white"
+      : "text-white/55 hover:bg-white/[0.04] hover:text-white"
+  }`;
+
+  const inner = (
+    <>
+      <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center">
+        {icon}
+      </span>
+      <span className="whitespace-nowrap opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+        {label}
+      </span>
+      {active ? (
+        <span
+          aria-hidden
+          className="absolute left-0 top-1/2 h-4 w-0.5 -translate-y-1/2 rounded-r-full bg-[#3ecf8e]"
+        />
+      ) : null}
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        aria-label={label}
+        title={label}
+        className={cls}
+        onClick={onClick}
+      >
+        {inner}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className={cls}
+    >
+      {inner}
+    </button>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Sub-sidebar (sectioned navigation)                                        */
+/* -------------------------------------------------------------------------- */
+
+function SubSidebar({
+  tool,
+  sections,
+  activeItem,
+  onSelectItem,
+}: {
+  tool: Tool;
+  sections: SubSection[];
+  activeItem: string;
+  onSelectItem: (id: string) => void;
+}) {
+  return (
+    <aside className="hidden w-[200px] shrink-0 flex-col border-r border-white/[0.08] bg-[#171717] sm:flex md:w-[220px]">
+      <SubSidebarHeader tool={tool} />
+      <SubSidebarBody
+        sections={sections}
+        activeItem={activeItem}
+        onSelectItem={onSelectItem}
+      />
+    </aside>
+  );
+}
+
+function SubSidebarHeader({ tool }: { tool: Tool }) {
+  return (
+    <header className="flex items-center justify-between border-b border-white/[0.06] px-4 py-3">
+      <h2 className="text-[15px] font-medium tracking-[-0.01em] text-white">
+        {tool.name}
+      </h2>
+      <button
+        type="button"
+        aria-label={tool.createLabel}
+        title={tool.createLabel}
+        className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-white/[0.08] bg-white/[0.03] text-white/70 transition-colors hover:border-[#3ecf8e]/40 hover:bg-[#3ecf8e]/10 hover:text-[#3ecf8e]"
+      >
+        <Plus className="h-3.5 w-3.5" aria-hidden />
+      </button>
+    </header>
+  );
+}
+
+function SubSidebarBody({
+  sections,
+  activeItem,
+  onSelectItem,
+}: {
+  sections: SubSection[];
+  activeItem: string;
+  onSelectItem: (id: string) => void;
+}) {
+  return (
+    <nav
+      aria-label="Sub navigation"
+      className="flex-1 overflow-y-auto p-2"
+    >
+      {sections.map((section) => (
+        <div key={section.title} className="mb-3 last:mb-0">
+          <h3 className="mb-1 px-2.5 text-[10px] font-medium uppercase tracking-[0.12em] text-white/35">
+            {section.title}
+          </h3>
+          <ul className="flex flex-col gap-px">
+            {section.items.map((item) => (
+              <li key={item.id}>
+                <SubItemButton
+                  item={item}
+                  active={item.id === activeItem}
+                  onClick={() => onSelectItem(item.id)}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  );
+}
+
+function SubItemButton({
+  item,
+  active,
+  onClick,
+}: {
+  item: SubItem;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex w-full items-center justify-between gap-2 rounded-md px-2.5 py-1.5 text-left text-[13px] transition-colors ${
+        active
+          ? "bg-white/[0.06] text-white"
+          : "text-white/65 hover:bg-white/[0.04] hover:text-white"
+      }`}
+    >
+      <span className="truncate">{item.label}</span>
+      {item.external ? (
+        <ExternalLink className="h-3 w-3 shrink-0 text-white/35" aria-hidden />
+      ) : null}
+    </button>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Mobile drawer                                                             */
+/* -------------------------------------------------------------------------- */
+
+function MobileDrawer({
+  tool,
+  sections,
+  activeTool,
+  activeItem,
+  onChangeTool,
+  onSelectItem,
+  onClose,
+}: {
+  tool: Tool;
+  sections: SubSection[];
+  activeTool: ToolId;
+  activeItem: string;
+  onChangeTool: (id: ToolId) => void;
+  onSelectItem: (id: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-40 flex sm:hidden">
+      <button
+        type="button"
+        aria-label="Close navigation"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/60"
+      />
+
+      {/* Side-by-side layout: primary rail + sub-sidebar, mirroring desktop */}
+      <aside className="relative flex w-[92%] max-w-[320px] bg-[#0f0f0f] shadow-[16px_0_48px_rgba(0,0,0,0.45)]">
+        {/* Primary rail */}
+        <div className="flex w-12 shrink-0 flex-col border-r border-white/[0.08] py-2">
+          <nav
+            aria-label="Tools"
+            className="flex flex-col items-center gap-0.5 px-1.5"
+          >
+            <RailButton
+              icon={<Home className="h-4 w-4" aria-hidden />}
+              label="Home"
+              href="/"
+              onClick={onClose}
+            />
+            <Separator />
+            {TOOLS.map((t) => (
+              <RailButton
+                key={t.id}
+                icon={<t.icon className="h-4 w-4" aria-hidden />}
+                label={t.name}
+                active={t.id === activeTool}
+                onClick={() => onChangeTool(t.id)}
+              />
+            ))}
+          </nav>
+
+          <div className="mt-auto flex flex-col items-center gap-0.5 px-1.5">
+            <Separator />
+            <RailButton
+              icon={<Settings className="h-4 w-4" aria-hidden />}
+              label="Settings"
+            />
+          </div>
+        </div>
+
+        {/* Sub-sidebar */}
+        <div className="flex min-w-0 flex-1 flex-col bg-[#171717]">
+          <div className="flex h-12 items-center justify-between border-b border-white/[0.08] px-2">
+            <Link
+              href="/"
+              onClick={onClose}
+              className="flex items-center gap-2 px-1 text-[13px] font-medium tracking-[-0.01em]"
+            >
+              <span
+                aria-hidden
+                className="inline-block h-2 w-2 rounded-full bg-[#3ecf8e] shadow-[0_0_8px_#3ecf8e]"
+              />
+              yoga<span className="text-[#3ecf8e]">.</span>
+            </Link>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md text-white/70 hover:bg-white/5 hover:text-white"
+            >
+              <X className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+          <SubSidebarHeader tool={tool} />
+          <SubSidebarBody
+            sections={sections}
+            activeItem={activeItem}
+            onSelectItem={onSelectItem}
+          />
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/app/dashboard/views.tsx
+++ b/src/app/dashboard/views.tsx
@@ -1,0 +1,512 @@
+"use client";
+
+import {
+  Activity,
+  ArrowUp,
+  Bot,
+  Cpu,
+  Globe,
+  HardDrive,
+  MemoryStick,
+  Play,
+  Plus,
+  RotateCw,
+  Square,
+  TerminalSquare,
+  User,
+} from "lucide-react";
+
+import type {
+  AiRoute,
+  ChatConversation,
+  ChatMessage,
+  VpsInstance,
+  VpsStatus,
+} from "./data";
+import { AI_RECENT_CALLS } from "./data";
+
+/* -------------------------------------------------------------------------- */
+/*  VPS                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export function VpsView({ instance }: { instance: VpsInstance }) {
+  const metrics = [
+    { label: "CPU", value: `${instance.cpu}%`, pct: instance.cpu, icon: Cpu, sub: `${instance.vcpu} vCPU` },
+    { label: "Memory", value: `${instance.memory}%`, pct: instance.memory, icon: MemoryStick, sub: `${instance.memoryGb} GB` },
+    { label: "Disk", value: `${instance.disk}%`, pct: instance.disk, icon: HardDrive, sub: `${instance.diskGb} GB SSD` },
+    { label: "Network", value: "48 Mb/s", pct: 32, icon: Activity, sub: "in/out" },
+  ];
+
+  return (
+    <div className="flex flex-col gap-6 p-6 sm:p-8">
+      {/* Header */}
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <StatusDot status={instance.status} />
+            <h2 className="font-mono text-[22px] font-medium tracking-[-0.01em] text-white">
+              {instance.name}
+            </h2>
+            <StatusBadge status={instance.status} />
+          </div>
+          <div className="mt-1.5 flex flex-wrap items-center gap-3 text-[13px] text-white/55">
+            <span className="inline-flex items-center gap-1.5">
+              <Globe className="h-3.5 w-3.5" aria-hidden />
+              {instance.region}
+            </span>
+            <span className="text-white/20">·</span>
+            <span className="font-mono">{instance.ipv4}</span>
+            <span className="text-white/20">·</span>
+            <span>uptime {instance.uptime}</span>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {instance.status === "running" ? (
+            <Action icon={Square} label="Stop" />
+          ) : (
+            <Action icon={Play} label="Start" primary />
+          )}
+          <Action icon={RotateCw} label="Reboot" />
+          <Action icon={TerminalSquare} label="SSH" />
+        </div>
+      </header>
+
+      {/* Metrics grid */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        {metrics.map(({ label, value, pct, icon: Icon, sub }) => (
+          <div
+            key={label}
+            className="rounded-lg border border-white/[0.08] bg-[#171717] p-4"
+          >
+            <div className="flex items-center justify-between text-white/40">
+              <span className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.1em]">
+                <Icon className="h-3 w-3" aria-hidden />
+                {label}
+              </span>
+              <span className="font-mono text-[10px]">{sub}</span>
+            </div>
+            <div className="mt-2 text-[22px] font-medium tracking-tight text-white">
+              {value}
+            </div>
+            <div className="mt-3 h-1 w-full overflow-hidden rounded-full bg-white/[0.06]">
+              <div
+                className="h-full rounded-full bg-[#3ecf8e]"
+                style={{ width: `${Math.max(2, pct)}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* SSH + log */}
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[1fr_1fr]">
+        <CodeBlock
+          title="SSH"
+          lines={[
+            `$ ssh root@${instance.ipv4}`,
+            "Welcome to Ubuntu 24.04 LTS",
+            "Last login: Tue May 13 09:32:11 +08 2026",
+          ]}
+        />
+        <Panel title="Recent activity">
+          <ul className="divide-y divide-white/[0.04] font-mono text-[12px]">
+            <LogRow ts="09:32:11" text="SSH login from 103.157.xx.xx" />
+            <LogRow ts="09:15:02" text="systemd: bot-runner.service restarted" />
+            <LogRow ts="08:44:57" text="apt: 3 packages upgraded" tone="soft" />
+            <LogRow ts="04:12:00" text="cron: snapshot created" tone="soft" />
+          </ul>
+        </Panel>
+      </div>
+    </div>
+  );
+}
+
+function StatusDot({ status }: { status: VpsStatus }) {
+  const cls =
+    status === "running"
+      ? "bg-[#3ecf8e] shadow-[0_0_10px_#3ecf8e]"
+      : status === "rebooting"
+        ? "bg-yellow-400"
+        : "bg-white/30";
+  return <span aria-hidden className={`inline-block h-2 w-2 rounded-full ${cls}`} />;
+}
+
+function StatusBadge({ status }: { status: VpsStatus }) {
+  const cls =
+    status === "running"
+      ? "border-[#3ecf8e]/20 bg-[#3ecf8e]/10 text-[#3ecf8e]"
+      : status === "rebooting"
+        ? "border-yellow-500/20 bg-yellow-500/10 text-yellow-300"
+        : "border-white/[0.08] bg-white/[0.04] text-white/50";
+  return (
+    <span
+      className={`rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.1em] ${cls}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function Action({
+  icon: Icon,
+  label,
+  primary,
+}: {
+  icon: React.ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  label: string;
+  primary?: boolean;
+}) {
+  const base =
+    "inline-flex h-9 items-center gap-1.5 rounded-md px-3 text-[13px] font-medium transition-colors";
+  const style = primary
+    ? "bg-[#3ecf8e] text-[#171717] hover:bg-[#24b47e]"
+    : "border border-white/[0.1] bg-white/[0.03] text-white/85 hover:border-white/20 hover:bg-white/[0.06]";
+  return (
+    <button type="button" className={`${base} ${style}`}>
+      <Icon className="h-3.5 w-3.5" aria-hidden />
+      {label}
+    </button>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  AI Router                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export function AiRouterView({ route }: { route: AiRoute }) {
+  return (
+    <div className="flex flex-col gap-6 p-6 sm:p-8">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <span
+              aria-hidden
+              className={`inline-block h-2 w-2 rounded-full ${
+                route.active
+                  ? "bg-[#3ecf8e] shadow-[0_0_10px_#3ecf8e]"
+                  : "bg-white/30"
+              }`}
+            />
+            <h2 className="font-mono text-[22px] font-medium tracking-[-0.01em] text-white">
+              {route.name}
+            </h2>
+            <span className="rounded-full border border-[#3ecf8e]/20 bg-[#3ecf8e]/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.1em] text-[#3ecf8e]">
+              live
+            </span>
+          </div>
+          <div className="mt-1.5 flex flex-wrap items-center gap-3 text-[13px] text-white/55">
+            <span className="font-mono">{route.path}</span>
+            <span className="text-white/20">·</span>
+            <span>
+              <span className="text-white/70">{route.model}</span> ·{" "}
+              <span className="text-white/40">fallback</span>{" "}
+              <span className="text-white/70">{route.fallback}</span>
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Action icon={RotateCw} label="Replay last" />
+          <Action icon={Activity} label="Test call" primary />
+        </div>
+      </header>
+
+      {/* Metrics */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <MetricCard label="p50" value={route.p50} bar={0.4} />
+        <MetricCard label="p95" value={route.p95} bar={0.75} />
+        <MetricCard label="Errors" value={route.errors} bar={0.08} />
+        <MetricCard
+          label="Requests · 24h"
+          value={route.requests24h.toLocaleString()}
+          bar={0.6}
+        />
+      </div>
+
+      {/* Recent calls */}
+      <Panel title="Recent calls">
+        <ul className="divide-y divide-white/[0.04] font-mono text-[12px]">
+          {AI_RECENT_CALLS.map((c, i) => (
+            <li
+              key={i}
+              className="flex items-center gap-3 px-4 py-2"
+            >
+              <span className="w-16 shrink-0 text-white/40">{c.ts}</span>
+              <span className="shrink-0 rounded bg-[#3ecf8e]/15 px-1.5 py-0.5 text-[9px] font-semibold text-[#3ecf8e]">
+                {c.method}
+              </span>
+              <span className="min-w-0 flex-1 truncate text-white/80">{c.path}</span>
+              <span className="hidden truncate text-white/50 md:inline">
+                {c.model}
+              </span>
+              <span
+                className={`w-12 shrink-0 text-right ${
+                  c.status === 200
+                    ? "text-white/60"
+                    : c.status === 429
+                      ? "text-yellow-300"
+                      : "text-red-300"
+                }`}
+              >
+                {c.status}
+              </span>
+              <span className="w-16 shrink-0 text-right text-white/40">{c.ms}</span>
+            </li>
+          ))}
+        </ul>
+      </Panel>
+
+      {/* Config snippet */}
+      <CodeBlock
+        title="Request"
+        lines={[
+          `curl https://yoga.dev${route.path} \\`,
+          `  -H "Authorization: Bearer $YOGA_KEY" \\`,
+          `  -H "Content-Type: application/json" \\`,
+          `  -d '{`,
+          `    "route": "${route.name}",`,
+          `    "messages": [{"role":"user","content":"Hi"}]`,
+          `  }'`,
+        ]}
+      />
+    </div>
+  );
+}
+
+function MetricCard({
+  label,
+  value,
+  bar,
+}: {
+  label: string;
+  value: string;
+  bar: number;
+}) {
+  return (
+    <div className="rounded-lg border border-white/[0.08] bg-[#171717] p-4">
+      <div className="text-[11px] uppercase tracking-[0.1em] text-white/40">
+        {label}
+      </div>
+      <div className="mt-2 text-[22px] font-medium tracking-tight text-white">
+        {value}
+      </div>
+      <div className="mt-3 h-1 w-full overflow-hidden rounded-full bg-white/[0.06]">
+        <div
+          className="h-full rounded-full bg-[#3ecf8e]"
+          style={{ width: `${Math.round(bar * 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Chat AI                                                                   */
+/* -------------------------------------------------------------------------- */
+
+export function ChatView({ conversation }: { conversation: ChatConversation }) {
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <header className="flex items-center justify-between border-b border-white/[0.06] px-6 py-4 sm:px-8">
+        <div className="min-w-0">
+          <h2 className="truncate text-[17px] font-medium tracking-[-0.01em] text-white">
+            {conversation.title}
+          </h2>
+          <div className="mt-0.5 flex items-center gap-3 text-[12px] text-white/45">
+            <span className="font-mono">{conversation.model}</span>
+            <span className="text-white/20">·</span>
+            <span>{conversation.updatedAt}</span>
+          </div>
+        </div>
+        <button
+          type="button"
+          className="inline-flex h-8 items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-3 text-[12px] text-white/70 hover:border-white/20 hover:bg-white/[0.06] hover:text-white"
+        >
+          <Plus className="h-3.5 w-3.5" aria-hidden />
+          New
+        </button>
+      </header>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-6 py-6 sm:px-8">
+        <ul className="mx-auto flex max-w-3xl flex-col gap-5">
+          {conversation.messages.map((m) => (
+            <ChatBubble key={m.id} message={m} />
+          ))}
+        </ul>
+      </div>
+
+      {/* Input */}
+      <div className="border-t border-white/[0.06] bg-[#171717] px-6 py-4 sm:px-8">
+        <div className="mx-auto flex max-w-3xl items-end gap-2 rounded-lg border border-white/[0.08] bg-[#1c1c1c] p-2 focus-within:border-[#3ecf8e]/40">
+          <textarea
+            rows={1}
+            placeholder="Reply…"
+            className="max-h-40 min-h-[36px] flex-1 resize-none bg-transparent px-2 py-1.5 text-[14px] leading-relaxed text-white placeholder:text-white/30 focus:outline-none"
+          />
+          <button
+            type="button"
+            className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[#3ecf8e] text-[#171717] hover:bg-[#24b47e]"
+            aria-label="Send"
+          >
+            <ArrowUp className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChatBubble({ message }: { message: ChatMessage }) {
+  const isUser = message.role === "user";
+  const body = renderChatContent(message.content);
+
+  return (
+    <li className={`flex items-start gap-3 ${isUser ? "flex-row-reverse" : ""}`}>
+      <span
+        className={`mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border ${
+          isUser
+            ? "border-[#3ecf8e]/30 bg-[#3ecf8e]/15 text-[#3ecf8e]"
+            : "border-white/10 bg-white/[0.04] text-white/70"
+        }`}
+      >
+        {isUser ? (
+          <User className="h-3.5 w-3.5" aria-hidden />
+        ) : (
+          <Bot className="h-3.5 w-3.5" aria-hidden />
+        )}
+      </span>
+      <div
+        className={`max-w-[85%] rounded-lg border px-4 py-3 text-[14px] leading-relaxed ${
+          isUser
+            ? "border-[#3ecf8e]/20 bg-[#3ecf8e]/5 text-white"
+            : "border-white/[0.08] bg-[#171717] text-white/85"
+        }`}
+      >
+        {body}
+      </div>
+    </li>
+  );
+}
+
+function renderChatContent(content: string) {
+  // Extremely tiny markdown: fenced code blocks only. Everything else is plain text.
+  const parts = content.split(/(```[\s\S]*?```)/g);
+  return parts.map((part, i) => {
+    if (part.startsWith("```") && part.endsWith("```")) {
+      const body = part.slice(3, -3).replace(/^[a-zA-Z]+\n/, "");
+      return (
+        <pre
+          key={i}
+          className="my-2 overflow-x-auto rounded-md border border-white/[0.06] bg-[#0f0f0f] p-3 font-mono text-[12px] text-white/90"
+        >
+          <code>{body}</code>
+        </pre>
+      );
+    }
+    return (
+      <span key={i} className="whitespace-pre-wrap">
+        {part}
+      </span>
+    );
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Shared                                                                    */
+/* -------------------------------------------------------------------------- */
+
+function Panel({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="overflow-hidden rounded-lg border border-white/[0.08] bg-[#171717]">
+      <header className="flex items-center justify-between border-b border-white/[0.06] px-4 py-2.5">
+        <span className="text-[11px] uppercase tracking-[0.1em] text-white/40">
+          {title}
+        </span>
+      </header>
+      {children}
+    </section>
+  );
+}
+
+function CodeBlock({ title, lines }: { title: string; lines: string[] }) {
+  return (
+    <section className="overflow-hidden rounded-lg border border-white/[0.08] bg-[#0f0f0f]">
+      <header className="flex items-center justify-between border-b border-white/[0.06] px-4 py-2.5">
+        <span className="text-[11px] uppercase tracking-[0.1em] text-white/40">
+          {title}
+        </span>
+        <button
+          type="button"
+          className="text-[11px] text-white/40 transition-colors hover:text-white/80"
+        >
+          Copy
+        </button>
+      </header>
+      <pre className="overflow-x-auto px-4 py-3 font-mono text-[12px] leading-relaxed text-white/90">
+        <code>{lines.join("\n")}</code>
+      </pre>
+    </section>
+  );
+}
+
+function LogRow({
+  ts,
+  text,
+  tone,
+}: {
+  ts: string;
+  text: string;
+  tone?: "soft";
+}) {
+  return (
+    <li className="flex items-center gap-3 px-4 py-2">
+      <span className="w-16 shrink-0 text-white/40">{ts}</span>
+      <span className={tone === "soft" ? "text-white/50" : "text-white/80"}>
+        {text}
+      </span>
+    </li>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Placeholder — config / platform pages we haven't built yet                */
+/* -------------------------------------------------------------------------- */
+
+export function PlaceholderView({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex h-full items-center justify-center p-6 sm:p-8">
+      <div className="max-w-md text-center">
+        <div className="mx-auto inline-flex h-10 w-10 items-center justify-center rounded-md border border-white/[0.08] bg-white/[0.03] text-white/50">
+          <Plus className="h-4 w-4" aria-hidden />
+        </div>
+        <h2 className="mt-4 text-[20px] font-medium tracking-[-0.01em] text-white">
+          {title}
+        </h2>
+        <p className="mt-2 text-[14px] leading-relaxed text-white/55">
+          {description}
+        </p>
+        <span className="mt-4 inline-flex items-center gap-1.5 rounded-full border border-white/[0.08] bg-white/[0.03] px-2.5 py-1 text-[11px] uppercase tracking-[0.12em] text-white/50">
+          <span
+            aria-hidden
+            className="h-1.5 w-1.5 rounded-full bg-[#3ecf8e]"
+          />
+          Coming soon
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
 
@@ -106,7 +107,7 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-  --font-sans: var(--font-geist-sans), "Inter", "Helvetica Neue", Arial, sans-serif;
+  --font-sans: "Inter", sans-serif;
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: var(--font-geist-mono), ui-monospace, Menlo, Monaco, Consolas, monospace;
   --shadow-color: #000000;
@@ -162,7 +163,7 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
-  --font-sans: var(--font-geist-sans), "Inter", "Helvetica Neue", Arial, sans-serif;
+  --font-sans: "Inter", sans-serif;
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: var(--font-geist-mono), ui-monospace, Menlo, Monaco, Consolas, monospace;
   --shadow-color: #000000;
@@ -185,6 +186,7 @@
 
 @layer base {
   body {
+    font-family: "Inter", sans-serif;
     letter-spacing: var(--tracking-normal);
     @apply bg-background text-foreground;
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -29,7 +25,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`dark ${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`dark ${geistMono.variable} h-full antialiased`}
       suppressHydrationWarning
     >
       <body className="min-h-full flex flex-col bg-[#1c1c1c] text-white">


### PR DESCRIPTION
## Summary
- Adds the authenticated `/dashboard` workspace with primary sidebar (collapsed, expands on hover) and a tool-specific sub-sidebar
- Implements dashboard views and data schemas for VPS control and AI routing management
- Minor updates to `globals.css` and root `layout.tsx` to support the new dashboard shell

#### Test plan
- [x] `npm run dev` and verify `/dashboard` renders without errors
- [x] Primary sidebar stays collapsed by default and expands on hover
- [x] Switching tools updates the sub-sidebar contents (VPS instances, AI router models)
- [x] Layout works on mobile and desktop

Generated with [Devin](https://cli.devin.ai/docs)