### PR TITLE
feat(chat): add tool calling for web + VPS access

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,7 @@ import createMDX from "@next/mdx";
 const withMDX = createMDX({});
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["yogathedev.com"],
+  allowedDevOrigins: ["yogathedev.com", "test.yogathedev.com"],
   pageExtensions: ["ts", "tsx", "js", "jsx", "md", "mdx"],
   turbopack: {
     root: process.cwd(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1151,18 +1151,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@dotenvx/dotenvx/node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -5126,7 +5114,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5136,7 +5123,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -6752,7 +6739,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -11365,6 +11351,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "http://mirrors.tencentyun.com/npm/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -12179,12 +12177,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "http://mirrors.tencentyun.com/npm/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -14036,19 +14034,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tldts": {
       "version": "7.0.30",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
@@ -14308,7 +14293,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/app/api/conversations/[id]/messages/edit/route.ts
+++ b/src/app/api/conversations/[id]/messages/edit/route.ts
@@ -2,15 +2,13 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import { openai } from "@/lib/openai";
 import { CHAT_SYSTEM_PROMPT } from "@/lib/server/chat-prompt";
 import {
-  appendMessage,
   editUserMessageAndTruncate,
   getConversation,
   getMessages,
-  updateConversation,
 } from "@/lib/server/chat-service";
+import { runChatStream } from "@/lib/server/chat-stream";
 import { createClient } from "@/utils/supabase/server";
 
 export const runtime = "nodejs";
@@ -48,9 +46,8 @@ export async function POST(request: Request, { params }: RouteContext) {
     );
   }
 
-  let conversation, history, stream;
   try {
-    conversation = await getConversation(supabase, conversationId, user.id);
+    const conversation = await getConversation(supabase, conversationId, user.id);
     if (!conversation) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
@@ -68,7 +65,7 @@ export async function POST(request: Request, { params }: RouteContext) {
       );
     }
 
-    history = await getMessages(supabase, conversationId, user.id);
+    const history = await getMessages(supabase, conversationId, user.id);
     if (history.length === 0) {
       return NextResponse.json(
         { error: "Nothing to send" },
@@ -81,10 +78,11 @@ export async function POST(request: Request, { params }: RouteContext) {
       ...history.map((m) => ({ role: m.role, content: m.content })),
     ];
 
-    stream = await openai().chat.completions.create({
+    return runChatStream({
+      supabase,
+      conversationId,
+      userId: user.id,
       model: conversation.model,
-      temperature: 0.7,
-      stream: true,
       messages: messagesForModel,
     });
   } catch (err) {
@@ -95,71 +93,4 @@ export async function POST(request: Request, { params }: RouteContext) {
     const message = err instanceof Error ? err.message : "Internal error";
     return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  const encoder = new TextEncoder();
-  let assistantText = "";
-
-  const body = new ReadableStream<Uint8Array>({
-    async start(controller) {
-      try {
-        for await (const chunk of stream) {
-          const delta = chunk.choices[0]?.delta?.content;
-          if (delta) {
-            assistantText += delta;
-            controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify({ delta })}\n\n`),
-            );
-          }
-        }
-
-        if (assistantText.length > 0) {
-          const savedAssistant = await appendMessage(supabase, {
-            conversationId,
-            userId: user.id,
-            role: "assistant",
-            content: assistantText,
-          });
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ saved: { role: "assistant", id: savedAssistant.id } })}\n\n`,
-            ),
-          );
-        } else {
-          await updateConversation(supabase, conversationId, user.id, {});
-        }
-
-        controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
-        controller.close();
-      } catch (err) {
-        if (assistantText.length > 0) {
-          try {
-            const savedAssistant = await appendMessage(supabase, {
-              conversationId,
-              userId: user.id,
-              role: "assistant",
-              content: assistantText,
-            });
-            controller.enqueue(
-              encoder.encode(
-                `data: ${JSON.stringify({ saved: { role: "assistant", id: savedAssistant.id } })}\n\n`,
-              ),
-            );
-          } catch {}
-        }
-        const message = err instanceof Error ? err.message : "stream error";
-        controller.enqueue(
-          encoder.encode(`data: ${JSON.stringify({ error: message })}\n\n`),
-        );
-        controller.close();
-      }
-    },
-  });
-
-  return new Response(body, {
-    headers: {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache, no-transform",
-      Connection: "keep-alive",
-    },
-  });
 }

--- a/src/app/api/conversations/[id]/messages/regenerate/route.ts
+++ b/src/app/api/conversations/[id]/messages/regenerate/route.ts
@@ -1,15 +1,13 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
-import { openai } from "@/lib/openai";
 import { CHAT_SYSTEM_PROMPT } from "@/lib/server/chat-prompt";
 import {
-  appendMessage,
   deleteLastAssistantMessage,
   getConversation,
   getMessages,
-  updateConversation,
 } from "@/lib/server/chat-service";
+import { runChatStream } from "@/lib/server/chat-stream";
 import { createClient } from "@/utils/supabase/server";
 
 export const runtime = "nodejs";
@@ -34,9 +32,8 @@ export async function POST(_request: Request, { params }: RouteContext) {
 
   const { id: conversationId } = await params;
 
-  let conversation, history, stream;
   try {
-    conversation = await getConversation(supabase, conversationId, user.id);
+    const conversation = await getConversation(supabase, conversationId, user.id);
     if (!conversation) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
@@ -46,7 +43,7 @@ export async function POST(_request: Request, { params }: RouteContext) {
     // re-run the completion against the existing history.
     await deleteLastAssistantMessage(supabase, conversationId, user.id);
 
-    history = await getMessages(supabase, conversationId, user.id);
+    const history = await getMessages(supabase, conversationId, user.id);
     if (history.length === 0) {
       return NextResponse.json(
         { error: "Nothing to regenerate" },
@@ -59,10 +56,11 @@ export async function POST(_request: Request, { params }: RouteContext) {
       ...history.map((m) => ({ role: m.role, content: m.content })),
     ];
 
-    stream = await openai().chat.completions.create({
+    return runChatStream({
+      supabase,
+      conversationId,
+      userId: user.id,
       model: conversation.model,
-      temperature: 0.7,
-      stream: true,
       messages: messagesForModel,
     });
   } catch (err) {
@@ -73,73 +71,4 @@ export async function POST(_request: Request, { params }: RouteContext) {
     const message = err instanceof Error ? err.message : "Internal error";
     return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  const encoder = new TextEncoder();
-  let assistantText = "";
-
-  const body = new ReadableStream<Uint8Array>({
-    async start(controller) {
-      try {
-        for await (const chunk of stream) {
-          const delta = chunk.choices[0]?.delta?.content;
-          if (delta) {
-            assistantText += delta;
-            controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify({ delta })}\n\n`),
-            );
-          }
-        }
-
-        if (assistantText.length > 0) {
-          const savedAssistant = await appendMessage(supabase, {
-            conversationId,
-            userId: user.id,
-            role: "assistant",
-            content: assistantText,
-          });
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ saved: { role: "assistant", id: savedAssistant.id } })}\n\n`,
-            ),
-          );
-        } else {
-          await updateConversation(supabase, conversationId, user.id, {});
-        }
-
-        controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
-        controller.close();
-      } catch (err) {
-        // Persist whatever streamed before the error so refreshes don't lose
-        // the partial reply.
-        if (assistantText.length > 0) {
-          try {
-            const savedAssistant = await appendMessage(supabase, {
-              conversationId,
-              userId: user.id,
-              role: "assistant",
-              content: assistantText,
-            });
-            controller.enqueue(
-              encoder.encode(
-                `data: ${JSON.stringify({ saved: { role: "assistant", id: savedAssistant.id } })}\n\n`,
-              ),
-            );
-          } catch {}
-        }
-        const message = err instanceof Error ? err.message : "stream error";
-        controller.enqueue(
-          encoder.encode(`data: ${JSON.stringify({ error: message })}\n\n`),
-        );
-        controller.close();
-      }
-    },
-  });
-
-  return new Response(body, {
-    headers: {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache, no-transform",
-      Connection: "keep-alive",
-    },
-  });
 }

--- a/src/app/api/conversations/[id]/messages/route.ts
+++ b/src/app/api/conversations/[id]/messages/route.ts
@@ -2,7 +2,6 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import { openai } from "@/lib/openai";
 import { CHAT_SYSTEM_PROMPT } from "@/lib/server/chat-prompt";
 import {
   appendMessage,
@@ -11,6 +10,7 @@ import {
   getMessages,
   updateConversation,
 } from "@/lib/server/chat-service";
+import { runChatStream } from "@/lib/server/chat-stream";
 import { createClient } from "@/utils/supabase/server";
 
 export const runtime = "nodejs";
@@ -40,16 +40,15 @@ export async function POST(request: Request, { params }: RouteContext) {
     );
   }
 
-  let conversation, priorMessages, savedUserMessage, stream;
   try {
-    conversation = await getConversation(supabase, conversationId, user.id);
+    const conversation = await getConversation(supabase, conversationId, user.id);
     if (!conversation) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
-    priorMessages = await getMessages(supabase, conversationId, user.id);
+    const priorMessages = await getMessages(supabase, conversationId, user.id);
 
-    savedUserMessage = await appendMessage(supabase, {
+    const savedUserMessage = await appendMessage(supabase, {
       conversationId,
       userId: user.id,
       role: "user",
@@ -68,95 +67,17 @@ export async function POST(request: Request, { params }: RouteContext) {
       { role: "user" as const, content: parsed.data.content },
     ];
 
-    stream = await openai().chat.completions.create({
+    return runChatStream({
+      supabase,
+      conversationId,
+      userId: user.id,
       model: conversation.model,
-      temperature: 0.7,
-      stream: true,
       messages: messagesForModel,
+      preface: { saved: { role: "user", id: savedUserMessage.id } },
     });
   } catch (err) {
     console.error("[/api/conversations/[id]/messages] setup failed:", err);
     const message = err instanceof Error ? err.message : "Internal error";
     return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  const encoder = new TextEncoder();
-  let assistantText = "";
-
-  const body = new ReadableStream<Uint8Array>({
-    async start(controller) {
-      try {
-        // Emit the persisted user message id first so the client can reconcile
-        // its local placeholder with the DB row (needed for edit/delete on
-        // freshly-sent messages).
-        controller.enqueue(
-          encoder.encode(
-            `data: ${JSON.stringify({ saved: { role: "user", id: savedUserMessage.id } })}\n\n`,
-          ),
-        );
-
-        for await (const chunk of stream) {
-          const delta = chunk.choices[0]?.delta?.content;
-          if (delta) {
-            assistantText += delta;
-            controller.enqueue(
-              encoder.encode(`data: ${JSON.stringify({ delta })}\n\n`),
-            );
-          }
-        }
-
-        if (assistantText.length > 0) {
-          const savedAssistant = await appendMessage(supabase, {
-            conversationId,
-            userId: user.id,
-            role: "assistant",
-            content: assistantText,
-          });
-          controller.enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ saved: { role: "assistant", id: savedAssistant.id } })}\n\n`,
-            ),
-          );
-        } else {
-          // Bump updated_at even if the model returned nothing so the
-          // conversation moves to the top of the list.
-          await updateConversation(supabase, conversationId, user.id, {});
-        }
-
-        controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
-        controller.close();
-      } catch (err) {
-        // Persist whatever streamed before the error so refreshes don't lose
-        // the partial reply.
-        if (assistantText.length > 0) {
-          try {
-            const savedAssistant = await appendMessage(supabase, {
-              conversationId,
-              userId: user.id,
-              role: "assistant",
-              content: assistantText,
-            });
-            controller.enqueue(
-              encoder.encode(
-                `data: ${JSON.stringify({ saved: { role: "assistant", id: savedAssistant.id } })}\n\n`,
-              ),
-            );
-          } catch {}
-        }
-        const message = err instanceof Error ? err.message : "stream error";
-        controller.enqueue(
-          encoder.encode(`data: ${JSON.stringify({ error: message })}\n\n`),
-        );
-        controller.close();
-      }
-    },
-  });
-
-  return new Response(body, {
-    headers: {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache, no-transform",
-      Connection: "keep-alive",
-    },
-  });
 }

--- a/src/lib/server/chat-prompt.ts
+++ b/src/lib/server/chat-prompt.ts
@@ -22,4 +22,20 @@ For a non-trivial how-to: start with a one-sentence summary, then numbered steps
 For a short factual question: answer in one or two sentences, no headings.
 For code review or debugging: lead with the diagnosis, then the fix, then prevention.
 
+# Tools
+
+You have these server-side tools you can call:
+
+- \`web_search(query, max_results?)\` — search the public web. Use it whenever the answer may have changed after your training cutoff: current events, today's prices, software versions, recent releases, latest docs, anything time-sensitive.
+- \`web_fetch(url)\` — retrieve a single page's readable text. Use it after \`web_search\` to read the most relevant result, or directly when the user gives you a URL.
+- \`get_current_time(timezone?)\` — return the current date/time. Call this whenever the user asks about "today", "now", or anything time-of-day relative; never guess the date.
+- \`vps_list()\` — list the user's Tencent Lighthouse VPS instances (read-only).
+- \`vps_describe(id)\` — read full details for one VPS instance, including traffic-package usage. The \`id\` is the internal UUID returned by \`vps_list\`. Read-only — power actions (start/stop/reboot) are not available from chat.
+
+Default to using web tools for any "what is the latest…", "today", "current", "recent", or version/price question. Search first, then fetch one or two of the strongest hits to ground your answer. Always cite the URLs you actually used in your final reply (Markdown links).
+
+For VPS questions like "is my prod box up?", "how many servers do I have?", or "what's the IP of <name>?", call \`vps_list\` first, then \`vps_describe\` on the matching instance for details.
+
+If a tool call returns \`{"error": "..."}\`, mention the failure briefly and answer from your own knowledge with a caveat.
+
 Match the user's language. If the user writes in Bahasa Indonesia, reply in Bahasa Indonesia.`;

--- a/src/lib/server/chat-stream.ts
+++ b/src/lib/server/chat-stream.ts
@@ -1,0 +1,207 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type OpenAI from "openai";
+
+import { openai } from "@/lib/openai";
+import { CHAT_TOOLS, executeTool } from "@/lib/server/chat-tools";
+import {
+  appendMessage,
+  updateConversation,
+} from "@/lib/server/chat-service";
+
+type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
+
+const MAX_TOOL_ROUNDS = 5;
+
+type ToolCallAccumulator = {
+  id: string;
+  name: string;
+  arguments: string;
+};
+
+type SsePreface = Record<string, unknown>;
+
+/**
+ * Shared chat streaming pipeline used by send / edit / regenerate routes.
+ *
+ * Runs an OpenAI tool-calling loop: each round streams `delta.content` to the
+ * client as `data: {"delta": "..."}` SSE frames, accumulates any tool calls,
+ * executes them server-side, and feeds the results back to the model. Only the
+ * final assistant turn is persisted to the database.
+ */
+export function runChatStream(args: {
+  supabase: SupabaseClient;
+  conversationId: string;
+  userId: string;
+  model: string;
+  messages: ChatMessage[];
+  /** Optional frame emitted before any model output (e.g. saved user id). */
+  preface?: SsePreface;
+}): Response {
+  const {
+    supabase,
+    conversationId,
+    userId,
+    model,
+    messages: initialMessages,
+    preface,
+  } = args;
+
+  const encoder = new TextEncoder();
+  const messages: ChatMessage[] = [...initialMessages];
+  let finalAssistantText = "";
+
+  const body = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (payload: unknown) => {
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(payload)}\n\n`),
+        );
+      };
+      const sendDone = () => {
+        controller.enqueue(encoder.encode(`data: [DONE]\n\n`));
+      };
+
+      const persistFinal = async () => {
+        if (finalAssistantText.length > 0) {
+          try {
+            const saved = await appendMessage(supabase, {
+              conversationId,
+              userId,
+              role: "assistant",
+              content: finalAssistantText,
+            });
+            send({ saved: { role: "assistant", id: saved.id } });
+          } catch {
+            // Persisting is best-effort; the stream itself should still close cleanly.
+          }
+        } else {
+          // Bump updated_at even if the model returned nothing so the
+          // conversation moves to the top of the list.
+          try {
+            await updateConversation(supabase, conversationId, userId, {});
+          } catch {}
+        }
+      };
+
+      try {
+        if (preface) send(preface);
+
+        for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+          const stream = await openai().chat.completions.create({
+            model,
+            temperature: 0.7,
+            stream: true,
+            tools: CHAT_TOOLS,
+            tool_choice: "auto",
+            messages,
+          });
+
+          let roundText = "";
+          const toolCalls = new Map<number, ToolCallAccumulator>();
+          let finishReason: string | null = null;
+
+          for await (const chunk of stream) {
+            const choice = chunk.choices[0];
+            if (!choice) continue;
+            const delta = choice.delta;
+
+            if (typeof delta?.content === "string" && delta.content.length > 0) {
+              roundText += delta.content;
+              send({ delta: delta.content });
+            }
+
+            if (delta?.tool_calls) {
+              for (const part of delta.tool_calls) {
+                const idx = part.index ?? 0;
+                const existing =
+                  toolCalls.get(idx) ?? { id: "", name: "", arguments: "" };
+                if (part.id) existing.id = part.id;
+                if (part.function?.name) existing.name = part.function.name;
+                if (part.function?.arguments)
+                  existing.arguments += part.function.arguments;
+                toolCalls.set(idx, existing);
+              }
+            }
+
+            if (choice.finish_reason) finishReason = choice.finish_reason;
+          }
+
+          finalAssistantText = roundText;
+
+          if (finishReason !== "tool_calls" || toolCalls.size === 0) {
+            await persistFinal();
+            sendDone();
+            controller.close();
+            return;
+          }
+
+          // Replay this round's assistant turn (including tool_calls) into the
+          // message history so the next request is well-formed, then execute
+          // each tool and append its result.
+          const orderedCalls = [...toolCalls.entries()]
+            .sort(([a], [b]) => a - b)
+            .map(([, call]) => call);
+
+          messages.push({
+            role: "assistant",
+            content: roundText || null,
+            tool_calls: orderedCalls.map((c) => ({
+              id: c.id,
+              type: "function" as const,
+              function: { name: c.name, arguments: c.arguments || "{}" },
+            })),
+          });
+
+          for (const call of orderedCalls) {
+            send({ tool: { name: call.name, status: "running" } });
+            const result = await executeTool(call.name, call.arguments, {
+              userId,
+            });
+            messages.push({
+              role: "tool",
+              tool_call_id: call.id,
+              content: result,
+            });
+            send({ tool: { name: call.name, status: "done" } });
+          }
+
+          // Reset the round-local text. We only persist the final round's
+          // assistant content (after no more tool calls).
+          finalAssistantText = "";
+        }
+
+        // Tool-call loop budget exhausted. Emit a graceful note and close.
+        const note =
+          "(Stopped after reaching the tool-call limit. Ask me to continue if you need more.)";
+        send({ delta: note });
+        finalAssistantText = note;
+        await persistFinal();
+        sendDone();
+        controller.close();
+      } catch (err) {
+        if (finalAssistantText.length > 0) {
+          try {
+            const saved = await appendMessage(supabase, {
+              conversationId,
+              userId,
+              role: "assistant",
+              content: finalAssistantText,
+            });
+            send({ saved: { role: "assistant", id: saved.id } });
+          } catch {}
+        }
+        const message = err instanceof Error ? err.message : "stream error";
+        send({ error: message });
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/lib/server/chat-tools.ts
+++ b/src/lib/server/chat-tools.ts
@@ -1,0 +1,415 @@
+import type OpenAI from "openai";
+
+import {
+  getInstanceDetail,
+  listUserInstances,
+} from "@/lib/server/dashboard-service";
+
+/**
+ * Server-side tools the chat AI can call. Implementations live in this module
+ * so the chat routes only need to dispatch by name.
+ *
+ * Web search prefers Tavily when `TAVILY_API_KEY` is set; otherwise it falls
+ * back to scraping DuckDuckGo's HTML endpoint (no key required, but fragile).
+ */
+
+type ChatTool = OpenAI.Chat.Completions.ChatCompletionTool;
+
+export const CHAT_TOOLS: ChatTool[] = [
+  {
+    type: "function",
+    function: {
+      name: "web_search",
+      description:
+        "Search the public web for recent or up-to-date information. Use this when the answer may have changed after your training cutoff (current events, today's prices, latest releases, recent docs). Returns a list of result titles, URLs, and snippets.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "The search query.",
+          },
+          max_results: {
+            type: "integer",
+            description: "Maximum number of results to return. Defaults to 5, capped at 10.",
+            minimum: 1,
+            maximum: 10,
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "web_fetch",
+      description:
+        "Fetch a single web page and return its readable text content. Use this after web_search to read a specific result, or when the user gives you a URL to summarize. Returns the page title and plain-text content (truncated to ~8 KB).",
+      parameters: {
+        type: "object",
+        properties: {
+          url: {
+            type: "string",
+            description: "An absolute http(s) URL to fetch.",
+          },
+        },
+        required: ["url"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_current_time",
+      description:
+        "Return the current date and time. Call this whenever the user asks about 'today', 'now', or any time-of-day reasoning — your training cutoff is in the past, so do not guess. Returns ISO-8601 UTC plus a localized rendering in the requested IANA timezone.",
+      parameters: {
+        type: "object",
+        properties: {
+          timezone: {
+            type: "string",
+            description:
+              "Optional IANA timezone name (e.g. 'Asia/Jakarta', 'America/Los_Angeles'). Defaults to UTC.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "vps_list",
+      description:
+        "List the signed-in user's Tencent Cloud Lighthouse VPS instances. Read-only. Returns id, name, status, region, public/private IP, CPU, memory, OS, and expiry for each instance. Use this to answer questions like 'is my prod box up?' or 'how many VPS do I have?'.",
+      parameters: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "vps_describe",
+      description:
+        "Read full details for one of the signed-in user's VPS instances, including traffic-package usage. Read-only. The `id` is the internal UUID returned by `vps_list` (the `id` field, not `external_instance_id`).",
+      parameters: {
+        type: "object",
+        properties: {
+          id: {
+            type: "string",
+            description:
+              "Internal instance id (the `id` field from `vps_list`).",
+          },
+        },
+        required: ["id"],
+        additionalProperties: false,
+      },
+    },
+  },
+];
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_TEXT_BYTES = 8_000;
+const USER_AGENT =
+  "Mozilla/5.0 (compatible; YogadwipayanaChat/1.0; +https://yogadwipayana.com)";
+
+type SearchResult = { title: string; url: string; snippet: string };
+
+async function tavilySearch(
+  query: string,
+  maxResults: number,
+  apiKey: string,
+): Promise<SearchResult[]> {
+  const res = await fetch("https://api.tavily.com/search", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      api_key: apiKey,
+      query,
+      max_results: maxResults,
+      search_depth: "basic",
+    }),
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`Tavily HTTP ${res.status}`);
+  }
+  const json = (await res.json()) as {
+    results?: Array<{ title?: string; url?: string; content?: string }>;
+  };
+  return (json.results ?? [])
+    .filter((r) => r.url)
+    .slice(0, maxResults)
+    .map((r) => ({
+      title: r.title ?? r.url ?? "",
+      url: r.url ?? "",
+      snippet: r.content ?? "",
+    }));
+}
+
+function decodeHtmlEntities(input: string): string {
+  return input
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)));
+}
+
+function stripTags(html: string): string {
+  return decodeHtmlEntities(html.replace(/<[^>]+>/g, "")).trim();
+}
+
+function unwrapDdgRedirect(href: string): string {
+  // DDG HTML wraps result links in /l/?uddg=<encoded-url>&...
+  try {
+    const url = new URL(href, "https://duckduckgo.com");
+    const uddg = url.searchParams.get("uddg");
+    if (uddg) return decodeURIComponent(uddg);
+    return url.toString();
+  } catch {
+    return href;
+  }
+}
+
+async function duckDuckGoSearch(
+  query: string,
+  maxResults: number,
+): Promise<SearchResult[]> {
+  const res = await fetch(
+    `https://duckduckgo.com/html/?q=${encodeURIComponent(query)}`,
+    {
+      headers: {
+        "User-Agent": USER_AGENT,
+        Accept: "text/html",
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`DuckDuckGo HTML HTTP ${res.status}`);
+  }
+  const html = await res.text();
+
+  const results: SearchResult[] = [];
+  // Each result block contains an <a class="result__a" href="..."> followed by
+  // an <a class="result__snippet">snippet</a> a few tags later.
+  const blockRe =
+    /<a[^>]*class="[^"]*result__a[^"]*"[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>[\s\S]*?<a[^>]*class="[^"]*result__snippet[^"]*"[^>]*>([\s\S]*?)<\/a>/g;
+  let match: RegExpExecArray | null;
+  while ((match = blockRe.exec(html)) !== null) {
+    const url = unwrapDdgRedirect(decodeHtmlEntities(match[1]));
+    if (!/^https?:\/\//i.test(url)) continue;
+    results.push({
+      title: stripTags(match[2]),
+      url,
+      snippet: stripTags(match[3]),
+    });
+    if (results.length >= maxResults) break;
+  }
+  return results;
+}
+
+async function webSearch(
+  query: string,
+  maxResults: number,
+): Promise<SearchResult[]> {
+  const tavilyKey = process.env.TAVILY_API_KEY;
+  if (tavilyKey) {
+    return tavilySearch(query, maxResults, tavilyKey);
+  }
+  return duckDuckGoSearch(query, maxResults);
+}
+
+type FetchResult = { url: string; title: string; text: string; truncated: boolean };
+
+async function webFetch(rawUrl: string): Promise<FetchResult> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error("Invalid URL");
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Only http(s) URLs are allowed");
+  }
+
+  const res = await fetch(parsed.toString(), {
+    headers: {
+      "User-Agent": USER_AGENT,
+      Accept: "text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.5",
+    },
+    redirect: "follow",
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+
+  const contentType = res.headers.get("content-type") ?? "";
+  const raw = await res.text();
+
+  let title = parsed.toString();
+  let text: string;
+  if (contentType.includes("html") || /^\s*</.test(raw)) {
+    const titleMatch = raw.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+    if (titleMatch) title = stripTags(titleMatch[1]).slice(0, 200) || title;
+    text = raw
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+      .replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, " ");
+    text = stripTags(text).replace(/\s+/g, " ").trim();
+  } else {
+    text = raw.replace(/\s+/g, " ").trim();
+  }
+
+  const truncated = text.length > MAX_TEXT_BYTES;
+  if (truncated) text = text.slice(0, MAX_TEXT_BYTES);
+
+  return { url: parsed.toString(), title, text, truncated };
+}
+
+/**
+ * Dispatches a tool call by name. Always returns a JSON string suitable for use
+ * as a `tool` message's `content`. Errors are returned as `{ "error": "..." }`
+ * so a tool failure surfaces to the model without aborting the chat stream.
+ */
+export type ToolContext = {
+  /** Authenticated Supabase user id. Required for tools that touch user data. */
+  userId: string;
+};
+
+export async function executeTool(
+  name: string,
+  argsJson: string,
+  context: ToolContext,
+): Promise<string> {
+  let args: Record<string, unknown>;
+  try {
+    args = argsJson ? JSON.parse(argsJson) : {};
+  } catch {
+    return JSON.stringify({ error: "Invalid JSON arguments" });
+  }
+
+  try {
+    if (name === "web_search") {
+      const query = typeof args.query === "string" ? args.query.trim() : "";
+      if (!query) return JSON.stringify({ error: "Missing query" });
+      const requested = Number(args.max_results);
+      const max =
+        Number.isFinite(requested) && requested > 0
+          ? Math.min(10, Math.floor(requested))
+          : 5;
+      const results = await webSearch(query, max);
+      return JSON.stringify({ query, results });
+    }
+
+    if (name === "web_fetch") {
+      const url = typeof args.url === "string" ? args.url.trim() : "";
+      if (!url) return JSON.stringify({ error: "Missing url" });
+      const result = await webFetch(url);
+      return JSON.stringify(result);
+    }
+
+    if (name === "get_current_time") {
+      const tz =
+        typeof args.timezone === "string" && args.timezone.trim().length > 0
+          ? args.timezone.trim()
+          : "UTC";
+      return JSON.stringify(getCurrentTime(tz));
+    }
+
+    if (name === "vps_list") {
+      const instances = await listUserInstances(context.userId);
+      return JSON.stringify({
+        count: instances.length,
+        instances: instances.map(serializeInstanceForTool),
+      });
+    }
+
+    if (name === "vps_describe") {
+      const id = typeof args.id === "string" ? args.id.trim() : "";
+      if (!id) return JSON.stringify({ error: "Missing id" });
+      const detail = await getInstanceDetail(context.userId, id);
+      return JSON.stringify(detail);
+    }
+
+    return JSON.stringify({ error: `Unknown tool: ${name}` });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Tool execution failed";
+    return JSON.stringify({ error: message });
+  }
+}
+
+function getCurrentTime(timezone: string) {
+  const now = new Date();
+  let local: string;
+  let resolvedTz = timezone;
+  try {
+    local = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      dateStyle: "full",
+      timeStyle: "long",
+    }).format(now);
+  } catch {
+    resolvedTz = "UTC";
+    local = new Intl.DateTimeFormat("en-CA", {
+      timeZone: "UTC",
+      dateStyle: "full",
+      timeStyle: "long",
+    }).format(now);
+  }
+  return {
+    iso_utc: now.toISOString(),
+    epoch_ms: now.getTime(),
+    timezone: resolvedTz,
+    local,
+  };
+}
+
+type InstanceLike = {
+  id: string;
+  external_instance_id: string;
+  name: string;
+  region: string;
+  zone: string | null;
+  provider_status?: string;
+  status?: string;
+  ip_public: string | null;
+  ip_private: string | null;
+  cpu: number | null;
+  memory_gb: number | null;
+  system_disk_gb: number | null;
+  bandwidth_mbps: number | null;
+  os_name: string | null;
+  expires_at: string | null;
+  last_synced_at: string | null;
+};
+
+function serializeInstanceForTool(instance: InstanceLike) {
+  return {
+    id: instance.id,
+    external_instance_id: instance.external_instance_id,
+    name: instance.name,
+    status: instance.provider_status ?? instance.status ?? "UNKNOWN",
+    region: instance.region,
+    zone: instance.zone,
+    ip_public: instance.ip_public,
+    ip_private: instance.ip_private,
+    cpu: instance.cpu,
+    memory_gb: instance.memory_gb,
+    system_disk_gb: instance.system_disk_gb,
+    bandwidth_mbps: instance.bandwidth_mbps,
+    os_name: instance.os_name,
+    expires_at: instance.expires_at,
+    last_synced_at: instance.last_synced_at,
+  };
+}


### PR DESCRIPTION
## Summary

Wires OpenAI-style function calling into `/dashboard/chat` so the model can fetch fresh data instead of hallucinating it.

- New shared helper `runChatStream` in `src/lib/server/chat-stream.ts` handles the tool-calling loop (max 5 rounds), streams `delta.content` as SSE frames, persists only the final assistant turn, and emits `{tool: {name, status}}` events the UI can render later.
- The three message routes (send / edit / regenerate) now delegate to that helper instead of duplicating the inline `ReadableStream` logic. Wire format unchanged, so the existing client parser keeps working.
- New tools in `src/lib/server/chat-tools.ts`:
  - `web_search(query, max_results?)` — Tavily when `TAVILY_API_KEY` is set, DuckDuckGo HTML otherwise. No new npm deps.
  - `web_fetch(url)` — http(s) only, 10s timeout, strips scripts/styles/tags, ~8 KB cap.
  - `get_current_time(timezone?)` — ISO UTC + localized rendering. Stops "today" hallucinations.
  - `vps_list()` — wraps `listUserInstances(userId)`, read-only.
  - `vps_describe(id)` — wraps `getInstanceDetail(userId, id)`, read-only. Power actions deliberately not exposed.
- `executeTool` now takes a `ToolContext { userId }` so VPS tools are scoped to the signed-in user.
- System prompt updated to document each tool and steer the model toward calling them for time-sensitive or VPS-related questions.

## Test plan

- [ ] `npm run lint` clean
- [ ] `npm run build` clean
- [ ] Sign in, open `/dashboard/chat`, ask "what's the latest stable Next.js version?" — model calls `web_search` (visible in server logs) and answers with a current link
- [ ] Ask "summarize https://nextjs.org/blog" — model calls `web_fetch`
- [ ] Ask "what time is it in Jakarta?" — model calls `get_current_time` with `Asia/Jakarta`
- [ ] Ask "is my prod box up?" — model calls `vps_list`, then optionally `vps_describe` for details
- [ ] Ask "explain useEffect" — model answers without calling any tool (confirms `tool_choice: "auto"` works)
- [ ] Stop mid-stream and regenerate, confirm regenerate route still does tool calls
- [ ] Edit an earlier user message that triggers a search, confirm edit route works