### PR TITLE
feat(chat): add Chat/Image mode selector per conversation

### DIFF
--- a/src/app/api/conversations/[id]/messages/edit/route.ts
+++ b/src/app/api/conversations/[id]/messages/edit/route.ts
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import { CHAT_SYSTEM_PROMPT } from "@/lib/server/chat-prompt";
+import { CHAT_SYSTEM_PROMPT, IMAGE_MODE_SYSTEM_PROMPT } from "@/lib/server/chat-prompt";
 import {
   editUserMessageAndTruncate,
   getConversation,
@@ -75,6 +75,9 @@ export async function POST(request: Request, { params }: RouteContext) {
 
     const messagesForModel = [
       { role: "system" as const, content: CHAT_SYSTEM_PROMPT },
+      ...(conversation.mode === "image"
+        ? [{ role: "system" as const, content: IMAGE_MODE_SYSTEM_PROMPT }]
+        : []),
       ...history.map((m) => ({ role: m.role, content: m.content })),
     ];
 

--- a/src/app/api/conversations/[id]/messages/regenerate/route.ts
+++ b/src/app/api/conversations/[id]/messages/regenerate/route.ts
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
-import { CHAT_SYSTEM_PROMPT } from "@/lib/server/chat-prompt";
+import { CHAT_SYSTEM_PROMPT, IMAGE_MODE_SYSTEM_PROMPT } from "@/lib/server/chat-prompt";
 import {
   deleteLastAssistantMessage,
   getConversation,
@@ -53,6 +53,9 @@ export async function POST(_request: Request, { params }: RouteContext) {
 
     const messagesForModel = [
       { role: "system" as const, content: CHAT_SYSTEM_PROMPT },
+      ...(conversation.mode === "image"
+        ? [{ role: "system" as const, content: IMAGE_MODE_SYSTEM_PROMPT }]
+        : []),
       ...history.map((m) => ({ role: m.role, content: m.content })),
     ];
 

--- a/src/app/api/conversations/[id]/messages/route.ts
+++ b/src/app/api/conversations/[id]/messages/route.ts
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
-import { CHAT_SYSTEM_PROMPT } from "@/lib/server/chat-prompt";
+import { CHAT_SYSTEM_PROMPT, IMAGE_MODE_SYSTEM_PROMPT } from "@/lib/server/chat-prompt";
 import {
   appendMessage,
   deriveTitle,
@@ -63,6 +63,9 @@ export async function POST(request: Request, { params }: RouteContext) {
 
     const messagesForModel = [
       { role: "system" as const, content: CHAT_SYSTEM_PROMPT },
+      ...(conversation.mode === "image"
+        ? [{ role: "system" as const, content: IMAGE_MODE_SYSTEM_PROMPT }]
+        : []),
       ...priorMessages.map((m) => ({ role: m.role, content: m.content })),
       { role: "user" as const, content: parsed.data.content },
     ];

--- a/src/app/api/conversations/[id]/route.ts
+++ b/src/app/api/conversations/[id]/route.ts
@@ -15,6 +15,7 @@ export const runtime = "nodejs";
 const PatchBody = z.object({
   title: z.string().min(1).max(200).optional(),
   model: z.string().min(1).max(120).optional(),
+  mode: z.enum(["chat", "image"]).optional(),
 });
 
 type RouteContext = { params: Promise<{ id: string }> };
@@ -56,7 +57,11 @@ export async function PATCH(request: Request, { params }: RouteContext) {
     );
   }
 
-  if (parsed.data.title === undefined && parsed.data.model === undefined) {
+  if (
+    parsed.data.title === undefined &&
+    parsed.data.model === undefined &&
+    parsed.data.mode === undefined
+  ) {
     return NextResponse.json(
       { error: "Nothing to update" },
       { status: 400 },

--- a/src/app/dashboard/data.ts
+++ b/src/app/dashboard/data.ts
@@ -319,9 +319,17 @@ export type ChatMessage = {
   content: string;
 };
 
+export type ChatMode = "chat" | "image";
+
 export type ChatConversationSummary = {
   id: string;
   title: string;
   model: string;
+  mode: ChatMode;
   updated_at: string;
 };
+
+export const CHAT_MODES: { slug: ChatMode; name: string; description: string }[] = [
+  { slug: "chat", name: "Chat", description: "Regular text conversation" },
+  { slug: "image", name: "Image", description: "Generate images from prompts" },
+];

--- a/src/app/dashboard/views.tsx
+++ b/src/app/dashboard/views.tsx
@@ -16,6 +16,7 @@ import {
   ChevronUp,
   Copy,
   CreditCard,
+  ImagePlus,
   Key,
   Loader2,
   MessageSquare,
@@ -34,8 +35,9 @@ import type {
   AiRoute,
   ChatConversationSummary,
   ChatMessage,
+  ChatMode,
 } from "./data";
-import { AI_MODELS, AI_RECENT_CALLS } from "./data";
+import { AI_MODELS, AI_RECENT_CALLS, CHAT_MODES } from "./data";
 import { deriveConversationTitle } from "@/lib/chat-title";
 import { copyToClipboard } from "@/lib/utils";
 
@@ -318,6 +320,7 @@ export function ChatView({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [model, setModel] = useState(conversation.model || defaultModel || "");
+  const [mode, setMode] = useState<ChatMode>(conversation.mode ?? "chat");
   const [loaded, setLoaded] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -343,12 +346,19 @@ export function ChatView({
           return;
         }
         const data = (await res.json()) as {
-          conversation: { id: string; title: string; model: string; updated_at: string };
+          conversation: {
+            id: string;
+            title: string;
+            model: string;
+            mode: ChatMode;
+            updated_at: string;
+          };
           messages: ChatMessage[];
         };
         if (cancelled) return;
         setMessages(data.messages);
         setModel(data.conversation.model);
+        setMode(data.conversation.mode ?? "chat");
         setLoaded(true);
       } catch {
         if (!cancelled) setError("Failed to load conversation.");
@@ -421,6 +431,33 @@ export function ChatView({
       }
     },
     [conversation.id, model, onConversationUpdated],
+  );
+
+  const handleSelectMode = useCallback(
+    async (slug: ChatMode) => {
+      const previous = mode;
+      setMode(slug);
+      try {
+        const res = await fetch(`/api/conversations/${conversation.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ mode: slug }),
+        });
+        if (!res.ok) {
+          setMode((current) => (current === slug ? previous : current));
+          return;
+        }
+        const data = (await res.json()) as { conversation: ChatConversationSummary };
+        setMode((current) => {
+          if (current !== slug) return current;
+          onConversationUpdated?.(data.conversation);
+          return current;
+        });
+      } catch {
+        setMode((current) => (current === slug ? previous : current));
+      }
+    },
+    [conversation.id, mode, onConversationUpdated],
   );
 
   // Shared streaming consumer for both initial sends and regenerate. Mutates
@@ -555,6 +592,7 @@ export function ChatView({
           ? deriveConversationTitle(trimmed)
           : conversation.title,
         model,
+        mode,
         updated_at: new Date().toISOString(),
       });
     } catch (err) {
@@ -587,6 +625,7 @@ export function ChatView({
     isStreaming,
     messages.length,
     model,
+    mode,
     onConversationUpdated,
   ]);
 
@@ -628,6 +667,7 @@ export function ChatView({
         id: conversation.id,
         title: conversation.title,
         model,
+        mode,
         updated_at: new Date().toISOString(),
       });
     } catch (err) {
@@ -653,6 +693,7 @@ export function ChatView({
     isStreaming,
     messages,
     model,
+    mode,
     onConversationUpdated,
   ]);
 
@@ -721,6 +762,7 @@ export function ChatView({
           id: conversation.id,
           title: conversation.title,
           model,
+          mode,
           updated_at: new Date().toISOString(),
         });
       } catch (err) {
@@ -747,6 +789,7 @@ export function ChatView({
       isStreaming,
       messages,
       model,
+      mode,
       onConversationUpdated,
     ],
   );
@@ -878,7 +921,10 @@ export function ChatView({
               style={{ minHeight: "56px", maxHeight: "200px" }}
             />
             <div className="absolute bottom-0 left-0 right-0 flex items-center justify-between px-3 pb-3">
-              <ModelSelector model={model} onSelect={handleSelectModel} />
+              <div className="flex items-center gap-2">
+                <ModelSelector model={model} onSelect={handleSelectModel} />
+                <ModeSelector mode={mode} onSelect={handleSelectMode} />
+              </div>
               {isStreaming ? (
                 <button
                   type="button"
@@ -1363,6 +1409,120 @@ function ModelSelector({
                             {m.provider}
                           </span>
                         </div>
+                      </div>
+                      {selected && (
+                        <Check
+                          className="h-3.5 w-3.5 shrink-0 text-[#3ecf8e]"
+                          aria-hidden
+                        />
+                      )}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Mode selector dropdown                                                    */
+/* -------------------------------------------------------------------------- */
+
+function ModeSelector({
+  mode,
+  onSelect,
+}: {
+  mode: ChatMode;
+  onSelect: (slug: ChatMode) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const current = CHAT_MODES.find((m) => m.slug === mode) ?? CHAT_MODES[0];
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`group flex items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-[11px] tracking-tight transition-colors ${
+          open
+            ? "border-white/[0.14] bg-white/[0.05] text-white/80"
+            : "border-white/[0.08] bg-white/[0.02] text-white/55 hover:border-white/[0.14] hover:bg-white/[0.04] hover:text-white/80"
+        }`}
+        aria-label="Choose conversation mode"
+      >
+        <ImagePlus
+          className={`h-3 w-3 ${
+            mode === "image" ? "text-[#3ecf8e]/80" : "text-white/40"
+          }`}
+          aria-hidden
+        />
+        <span className="max-w-[120px] truncate">{current.name}</span>
+        <ChevronUp
+          className={`h-3 w-3 text-white/30 transition-transform group-hover:text-white/55 ${
+            open ? "rotate-180" : ""
+          }`}
+          aria-hidden
+        />
+      </button>
+
+      {open && (
+        <>
+          <button
+            type="button"
+            className="fixed inset-0 z-10"
+            aria-label="Close mode picker"
+            onClick={() => setOpen(false)}
+          />
+
+          <div className="absolute bottom-full left-0 z-20 mb-2 w-[240px] overflow-hidden rounded-lg border border-white/[0.08] bg-[#1a1a1a] shadow-[0_12px_40px_rgba(0,0,0,0.55)] ring-1 ring-black/30 backdrop-blur-sm">
+            <div className="flex items-center justify-between border-b border-white/[0.06] px-3 py-2">
+              <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-white/40">
+                Mode
+              </span>
+              <span className="text-[10px] text-white/25">{CHAT_MODES.length}</span>
+            </div>
+            <ul className="p-1.5">
+              {CHAT_MODES.map((m) => {
+                const selected = mode === m.slug;
+                return (
+                  <li key={m.slug}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onSelect(m.slug);
+                        setOpen(false);
+                      }}
+                      className={`group flex w-full items-center gap-3 rounded-md px-2.5 py-2 text-left transition-colors ${
+                        selected
+                          ? "bg-[#3ecf8e]/[0.08] text-white"
+                          : "text-white/70 hover:bg-white/[0.04] hover:text-white"
+                      }`}
+                    >
+                      <span
+                        aria-hidden
+                        className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border ${
+                          selected
+                            ? "border-[#3ecf8e]/35 bg-[#3ecf8e]/[0.1] text-[#3ecf8e]"
+                            : "border-white/[0.08] bg-white/[0.03] text-white/40 group-hover:border-white/[0.14] group-hover:text-white/60"
+                        }`}
+                      >
+                        {m.slug === "image" ? (
+                          <ImagePlus className="h-3 w-3" />
+                        ) : (
+                          <MessageSquare className="h-3 w-3" />
+                        )}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <span className="block truncate text-[13px] font-medium leading-tight">
+                          {m.name}
+                        </span>
+                        <span className="mt-0.5 block truncate text-[10px] text-white/35">
+                          {m.description}
+                        </span>
                       </div>
                       {selected && (
                         <Check

--- a/src/lib/server/chat-prompt.ts
+++ b/src/lib/server/chat-prompt.ts
@@ -67,3 +67,16 @@ If the user's request is ambiguous (e.g. "stop the server" with multiple instanc
 If a tool call returns \`{"error": "..."}\`, mention the failure briefly and answer from your own knowledge with a caveat.
 
 Match the user's language. If the user writes in Bahasa Indonesia, reply in Bahasa Indonesia.`;
+
+export const IMAGE_MODE_SYSTEM_PROMPT = `You are operating in **Image Generation mode**. Treat every user message as a request to produce an image, unless the user is clearly continuing a non-image conversation thread (e.g. asking a clarifying question about a previously generated image).
+
+Rules:
+
+- For each image request, call \`image_generate\` exactly once with a richly-detailed, descriptive prompt rewritten from the user's request. Add concrete style, lighting, composition, and subject details that the user implied but did not spell out.
+- Pick a sensible \`size\`: square subjects → \`1024x1024\`, wide/landscape → \`1536x1024\`, portrait/tall → \`1024x1536\`. If the user specifies a size or aspect ratio, honor it.
+- After the tool returns \`{ "url": "...", "prompt": "..." }\`, your reply MUST start with the markdown image: \`![brief alt text](url)\`. Do not paste the URL as a link, and do not omit the image.
+- Below the image, include the prompt you sent (as an italic line or a short blockquote) so the user can iterate. Keep any other prose minimal.
+- If the user asks for variations or "again with X different", call \`image_generate\` again with the adjusted prompt. Otherwise do not regenerate without being asked.
+- If the user's message is clearly NOT an image request (asking how the tool works, complaining, off-topic chat), reply normally without calling the tool, and gently remind them this conversation is in image mode.
+
+Match the user's language as usual.`;

--- a/src/lib/server/chat-service.ts
+++ b/src/lib/server/chat-service.ts
@@ -4,11 +4,14 @@ import { deriveConversationTitle } from "@/lib/chat-title";
 
 export { deriveConversationTitle as deriveTitle };
 
+export type ConversationMode = "chat" | "image";
+
 export type ConversationRow = {
   id: string;
   user_id: string;
   title: string;
   model: string;
+  mode: ConversationMode;
   created_at: string;
   updated_at: string;
 };
@@ -23,10 +26,10 @@ export type MessageRow = {
 
 export type ConversationSummary = Pick<
   ConversationRow,
-  "id" | "title" | "model" | "updated_at"
+  "id" | "title" | "model" | "mode" | "updated_at"
 >;
 
-const SUMMARY_COLS = "id,title,model,updated_at";
+const SUMMARY_COLS = "id,title,model,mode,updated_at";
 
 export async function listConversations(
   supabase: SupabaseClient,
@@ -81,13 +84,14 @@ export async function getMessages(
 
 export async function createConversation(
   supabase: SupabaseClient,
-  args: { userId: string; model: string; title?: string },
+  args: { userId: string; model: string; mode?: ConversationMode; title?: string },
 ): Promise<ConversationSummary> {
   const { data, error } = await supabase
     .from("conversation")
     .insert({
       user_id: args.userId,
       model: args.model,
+      ...(args.mode ? { mode: args.mode } : {}),
       ...(args.title ? { title: args.title } : {}),
     })
     .select(SUMMARY_COLS)
@@ -126,11 +130,12 @@ export async function updateConversation(
   supabase: SupabaseClient,
   id: string,
   userId: string,
-  patch: { title?: string; model?: string },
+  patch: { title?: string; model?: string; mode?: ConversationMode },
 ): Promise<ConversationSummary | null> {
   const fields: Record<string, unknown> = { updated_at: new Date().toISOString() };
   if (patch.title !== undefined) fields.title = patch.title;
   if (patch.model !== undefined) fields.model = patch.model;
+  if (patch.mode !== undefined) fields.mode = patch.mode;
 
   const { data, error } = await supabase
     .from("conversation")

--- a/supabase/migrations/20260521000000_conversation_mode.sql
+++ b/supabase/migrations/20260521000000_conversation_mode.sql
@@ -1,0 +1,6 @@
+-- Add `mode` to conversations so the chat UI can switch between
+-- regular chat and image generation per conversation.
+
+alter table public.conversation
+  add column if not exists mode text not null default 'chat'
+  check (mode in ('chat', 'image'));


### PR DESCRIPTION
## Summary

- Adds a Mode dropdown next to the model picker in the chat composer so each conversation can be switched between regular **Chat** and **Image generation**.
- Image mode appends an extra system prompt (`IMAGE_MODE_SYSTEM_PROMPT`) that steers the model to call `image_generate` and embed the result as a markdown image.
- Persists per-conversation via a new `mode` column on `public.conversation` (`chat` | `image`, default `chat`).

## Changes

- **Migration**: `supabase/migrations/20260521000000_conversation_mode.sql` adds the `mode` column with a check constraint.
- **Service / types**: `ConversationMode` threaded through `ConversationRow`, `ConversationSummary`, `ChatConversationSummary`, and the create/update helpers.
- **API**: `PATCH /api/conversations/:id` accepts `mode`; the messages, edit, and regenerate routes inject the image-mode system prompt when `conversation.mode === "image"`.
- **UI**: new `ModeSelector` mirrors `ModelSelector` (optimistic PATCH with rollback, click-outside backdrop, opens upward) and sits next to the model selector in the input toolbar.

## Test plan

- [ ] Apply migration: `supabase db push` (or via dashboard)
- [ ] Open `/dashboard/chat`, switch a conversation to Image mode
- [ ] Send a prompt like "a red panda on a skateboard" — assistant should call `image_generate` once and reply with an embedded markdown image
- [ ] Switch back to Chat mode, verify regular text replies resume
- [ ] Reload the page and confirm the mode persists per conversation
- [ ] Edit/regenerate a message in image mode — image-mode prompt should still apply

## Notes

- The Turbopack production build currently fails on `node_modules/ssh2` (`non-ecmascript placeable asset`), but this failure is pre-existing on `feat/chat` HEAD and unrelated to this change. Typecheck and ESLint pass on all touched files.